### PR TITLE
Fix GqlError component

### DIFF
--- a/src/components/shared/GqlError.js
+++ b/src/components/shared/GqlError.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const GqlError = error => (
+const GqlError = ({ error }) => (
   <div className="gql-error">
     <h1>There was an error</h1>
-    <p>{ error }</p>
+    <p>{ error.message }</p>
   </div>
 );
 


### PR DESCRIPTION
Wasn't destructuring `error` prop and was trying to render the `error` object.
Destructured `error` prop and rendered `error.message`